### PR TITLE
twitter-korean-text jar파일을 4.3.1로 버전업하는 풀 리퀘스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ target/
 
 # JAVA jar
 *.jar
+
+*.swp

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ except:
 __VERSION__ = "0.1.5"
 
 _JAVA_LIB_URLS = [
-    "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.4/scala-library-2.11.4.jar",
+    "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.7/scala-library-2.11.7.jar",
     "https://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.2/libthrift-0.9.2.jar",
     "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.14/snakeyaml-1.14.jar",
     "https://repo1.maven.org/maven2/com/twitter/twitter-text/1.13.0/twitter-text-1.13.0.jar",
-    "https://repo1.maven.org/maven2/com/twitter/penguin/korean-text/4.1.4/korean-text-4.1.4.jar",
+    "https://repo1.maven.org/maven2/com/twitter/penguin/korean-text/4.3.1/korean-text-4.3.1.jar",
 ]
 _PATH_TO_LIB = os.path.join(os.path.abspath(os.path.dirname((__file__))), "twkorean/data/lib")
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ _JAVA_LIB_URLS = [
     "https://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.2/libthrift-0.9.2.jar",
     "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.14/snakeyaml-1.14.jar",
     "https://repo1.maven.org/maven2/com/twitter/twitter-text/1.13.0/twitter-text-1.13.0.jar",
-    "https://repo1.maven.org/maven2/com/twitter/penguin/korean-text/4.4/korean-text-4.4.jar",
+    "https://repo1.maven.org/maven2/com/twitter/penguin/korean-text/4.4.4/korean-text-4.4.4.jar",
 ]
 _PATH_TO_LIB = os.path.join(os.path.abspath(os.path.dirname((__file__))), "twkorean/data/lib")
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ _JAVA_LIB_URLS = [
     "https://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.2/libthrift-0.9.2.jar",
     "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.14/snakeyaml-1.14.jar",
     "https://repo1.maven.org/maven2/com/twitter/twitter-text/1.13.0/twitter-text-1.13.0.jar",
-    "https://repo1.maven.org/maven2/com/twitter/penguin/korean-text/4.3.1/korean-text-4.3.1.jar",
+    "https://repo1.maven.org/maven2/com/twitter/penguin/korean-text/4.4/korean-text-4.4.jar",
 ]
 _PATH_TO_LIB = os.path.join(os.path.abspath(os.path.dirname((__file__))), "twkorean/data/lib")
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ _JAVA_LIB_URLS = [
     "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.4/scala-library-2.11.4.jar",
     "https://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.2/libthrift-0.9.2.jar",
     "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.14/snakeyaml-1.14.jar",
-    "https://repo1.maven.org/maven2/com/twitter/twitter-text/1.10.2/twitter-text-1.10.2.jar",
-    "https://repo1.maven.org/maven2/com/twitter/penguin/korean-text/2.3.3/korean-text-2.3.3.jar",
+    "https://repo1.maven.org/maven2/com/twitter/twitter-text/1.13.0/twitter-text-1.13.0.jar",
+    "https://repo1.maven.org/maven2/com/twitter/penguin/korean-text/4.1.4/korean-text-4.1.4.jar",
 ]
 _PATH_TO_LIB = os.path.join(os.path.abspath(os.path.dirname((__file__))), "twkorean/data/lib")
 

--- a/twkorean/escape.py
+++ b/twkorean/escape.py
@@ -82,7 +82,6 @@ def to_utf8(obj):
         return list(to_utf8(i) for i in obj)
     elif isinstance(obj, tuple):
         return tuple(to_utf8(i) for i in obj)
-
     return obj
 
 


### PR DESCRIPTION
### 주의사항
- https://github.com/originell/jpype/pull/161 머지가 완료된 JPype1에서만 정상적으로 동작합니다 (이슈 내용 : https://github.com/originell/jpype/issues/159 참고)
### twitter-korean-text jar파일을 4.3.1로 버전업하는 풀 리퀘스트
#### build.py
- 스칼라 라이브러리가 2.11.4에서 2.11.7로 업데이트됩니다.
- twitter-text 라이브러리가 1.10.2에서 1.13.0으로 업데이트됩니다.
- twitter-korean-text 라이브러리가 2.3.3 에서 4.3.1로 업데이트됩니다.
#### twkorean/**init**.py
- TwitterKoreanProcessor
  - _normalization, _stemming 변수를 추가 (각각 Processor가 Normalization, Stemming을 하는지에 대한 여부를 저장하는 용도)
  - stemming 메서드가 추가됩니다 
    - stemming을 KoreanProcessor에 있는 함수를 활용하여 사용하도록 변경되어서 해당 메서드를 추가합니다.
  - tokenize, tokenize_to_string에서 KoreanProcessor로부터 받는 object를 JPype1에서 iteratable collection으로 만들어주지 않기 때문에, 자체적으로 루틴을 추가합니다.
#### .gitignore
- *.swp 파일이 추가됩니다.
